### PR TITLE
chore!: use built asset if exist

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -7,8 +7,12 @@
         <meta name="csrf-token" content="{{ csrf_token() }}">
         <title>{{ config('app.name', 'Laravel') }}</title>
         <link rel="shortcut icon" href="{{ asset('Aset/Logo/favicon.png') }}" type="image/x-icon">
-        <!-- Scripts -->
-        @vite(['resources/css/app.css', 'resources/js/app.js'])
+        @if (file_exists(public_path('build/assets')))
+            <link rel="stylesheet" href="{{ asset('build/assets/css/app.css') }}">
+            <script src="{{ asset('build/assets/js/app2.js') }}" defer></script>
+        @else
+            @vite(['resources/css/app.css', 'resources/js/app.js'])
+        @endif
         <!-- Poppins -->
         <link rel="preconnect" href="https://fonts.googleapis.com">
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/vite.config.js
+++ b/vite.config.js
@@ -11,4 +11,14 @@ export default defineConfig({
             refresh: true,
         }),
     ],
+    build: {
+        outDir: 'public/build',
+        rollupOptions: {
+            output: {
+                assetFileNames: 'asset/[ext]/[name][extname]',
+                chunkFileNames: 'asset/[chunks]/[name].js',
+                entryFileNames: 'js/[name].js',
+            }
+        }
+    }
 });


### PR DESCRIPTION
BREAKING CHANGE: after npm run build, @vite in layout header will be disabled. Tailwind need to be recompiled to reflect class changes